### PR TITLE
Set system clipboard as clipboard buffer

### DIFF
--- a/lua/vim-options.lua
+++ b/lua/vim-options.lua
@@ -31,6 +31,7 @@ vim.api.nvim_create_autocmd("BufEnter", {
 vim.o.list = true
 vim.o.listchars = "tab: →,lead:.,trail:."
 vim.g.background = "light"
+vim.opt.clipboard = "unnamedplus"
 vim.opt.swapfile = false
 
 -- Navigate vim panes with motions.


### PR DESCRIPTION
This allows pasting from the system clipboard (with commands like "p") and writing to the system clipboard (with commands like "dd").

Resolves #9