### PR TITLE
feature/spectre

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -12,6 +12,7 @@
   "none-ls.nvim": { "branch": "main", "commit": "db2a48b79cfcdab8baa5d3f37f21c78b6705c62e" },
   "nvim-cmp": { "branch": "main", "commit": "b5311ab3ed9c846b585c0c15b7559be131ec4be9" },
   "nvim-lspconfig": { "branch": "master", "commit": "1cb30b1bafe5a63a5c6ac20dc39f83487df38855" },
+  "nvim-spectre": { "branch": "master", "commit": "72f56f7585903cd7bf92c665351aa585e150af0f" },
   "nvim-tmux-navigation": { "branch": "main", "commit": "4898c98702954439233fdaf764c39636681e2861" },
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-web-devicons": { "branch": "master", "commit": "19d6211c78169e78bab372b585b6fb17ad974e82" },

--- a/lua/plugins/spectre.lua
+++ b/lua/plugins/spectre.lua
@@ -1,0 +1,9 @@
+return {
+  "nvim-pack/nvim-spectre",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  config = function()
+    vim.keymap.set("n", "<leader>S", function()
+      require("spectre").toggle()
+    end, { desc = "Toggle Spectre" })
+  end,
+}


### PR DESCRIPTION
This PR adds support for [Spectre](https://github.com/nvim-pack/nvim-spectre). I'm trial running this plugin for now as an interactive search and replace functionality within Neovim.

You can easily give this a quick test using <leader>shift+s for search and then using <leader>shift+r for replacing all.