### PR TITLE
Fix ripgrep telescope search freeze

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -17,6 +17,11 @@ return {
         find_files = {
           theme = "ivy",
         },
+        live_grep = {
+          additional_args = function()
+            return { "--fixed-strings" }
+          end,
+        },
       },
       extensions = {
         fzf = {},


### PR DESCRIPTION
This PR fixes a bug that cuases Neovim to freeze while using Telescope fuzzy find. For example searching for something like `$test` will directly freeze before you can cancel it in most cases. You can prevent this issue by escaping the dollar sign symbol ex: `\$`, however, it's really easy to trigger this issue unintentionally.

## After

You can use `space + fg` to search for variables in PHP such as `$test`.

## How to Test

1. Perform a search with `space + fg`
2. Look for something like $test
3. It should not freeze the Neovim instance
